### PR TITLE
Fix double slash in urls

### DIFF
--- a/option/requestoption.go
+++ b/option/requestoption.go
@@ -231,14 +231,14 @@ func WithRequestTimeout(dur time.Duration) RequestOption {
 // environment to be the "production" environment. An environment specifies which base URL
 // to use by default.
 func WithEnvironmentProduction() RequestOption {
-	return WithBaseURL("https://api.terminal.shop//")
+	return WithBaseURL("https://api.terminal.shop/")
 }
 
 // WithEnvironmentDev returns a RequestOption that sets the current
 // environment to be the "dev" environment. An environment specifies which base URL
 // to use by default.
 func WithEnvironmentDev() RequestOption {
-	return WithBaseURL("https://api.dev.terminal.shop//")
+	return WithBaseURL("https://api.dev.terminal.shop/")
 }
 
 // WithBearerToken returns a RequestOption that sets the client setting "bearer_token".


### PR DESCRIPTION
While building a [Terraform provider](https://github.com/OZCAP/terraform-provider-terminal-coffee), I noticed that the urls appear to be formatted incorrectly in this SDK (double slash where should be only one). If I have missed anything, do let me know!